### PR TITLE
up

### DIFF
--- a/my-app.rb
+++ b/my-app.rb
@@ -3,13 +3,14 @@
 require 'sinatra'
 require 'net/http'
 require 'uri'
+require 'json'
 
-STORAGE = {}
 HOST = 'localhost'
 PORTS = [3000, 3001, 3002]
+STORAGE = { }
 
 get '/:key' do
-  value = STORAGE[params['key']]
+  value = define_value
   if value
     value
   else
@@ -21,13 +22,21 @@ end
 post '/replicate/:key' do
   (key, value) = [params['key'], request.body.read]
 
-  STORAGE[key] = value
+  update(key, value)
+  true
+end
+
+get '/:key/with_version' do
+  value = STORAGE[params['key']]
+  if value
+    value.to_json
+  else
+    status 404
+  end
 end
 
 post '/:key' do
   (key, value) = [params['key'], request.body.read]
-
-  STORAGE[key] = value
 
   friend_hosts = PORTS.select { |port| port != request.port }
   error_count = 0
@@ -49,6 +58,48 @@ post '/:key' do
   when 2
     false
   else
+    update(key, value)
     true
   end
+end
+
+def friend_values
+  @friend_values ||= request_values
+end
+
+def update(key, value)
+  STORAGE[key] = {} unless STORAGE.key?(key)
+  STORAGE[key]['value'] = value
+  STORAGE[key]['version'] = 0 if STORAGE[key]['version'].nil?
+  STORAGE[key]['version'] += 1
+end
+
+def request_values
+  values = []
+  friend_hosts = PORTS.select { |port| port != request.port }
+  friend_hosts.each do |port|
+    begin
+      uri = URI.parse("http://#{HOST}:#{port}/#{params['key']}/with_version")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new(uri.request_uri)
+      response = http.request(request)
+      values << JSON.parse(response.body) if response.kind_of? Net::HTTPSuccess
+    rescue => e
+    end
+  end
+
+  values
+end
+
+def define_value
+  return nil if friend_values.count.zero? || STORAGE[params['key']].nil?
+
+  friend_values << STORAGE[params['key']]
+  values_by_version = {}
+  friend_values.each do |value_and_version|
+    values_by_version[value_and_version['version']] = { 'value' => value_and_version['value'], 'count' => 0 } if values_by_version['version'].nil?
+    values_by_version[value_and_version['version']]['count'] += 1
+  end
+
+  values_by_version.max_by { |k, v| v['count'] }[1]['value']
 end


### PR DESCRIPTION
test result

```
HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
Content-Length: 0
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.4.2 (Ruby/2.7.0/2019-08-13)
Date: Sun, 22 Sep 2019 02:20:14 GMT
Connection: Keep-Alive

HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
Content-Length: 5
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.4.2 (Ruby/2.7.0/2019-08-13)
Date: Sun, 22 Sep 2019 02:20:14 GMT
Connection: Keep-Alive

tommy
pkill -9 -f 'my-app.rb -p 3000'
HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
Content-Length: 0
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.4.2 (Ruby/2.7.0/2019-08-13)
Date: Sun, 22 Sep 2019 02:20:14 GMT
Connection: Keep-Alive


HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
Content-Length: 7
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.4.2 (Ruby/2.7.0/2019-08-13)
Date: Sun, 22 Sep 2019 02:20:14 GMT
Connection: Keep-Alive

ujihisa
nohup bundle exec ruby my-app.rb -p 3000 >> log.txt 2>&1 &
HTTP/1.1 404 Not Found
Content-Type: text/html;charset=utf-8
Content-Length: 0
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.4.2 (Ruby/2.7.0/2019-08-13)
Date: Sun, 22 Sep 2019 02:20:15 GMT
Connection: Keep-Alive
```